### PR TITLE
CVF-7837 patch in support for 2022 jubilee bank hols

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 7.2.0.post1 (2022-05-30)
+
+FORK
+
+Cherry-pick:
+Fixed United Kingdom's 2022 holidays ; Spring Bank Holiday has been moved to the 3rd of June and Queen's Platinum Jubilee added to 2nd of June.
+
 ## v7.2.0 (2019-12-06)
 
 ### New calendars

--- a/bin/build-package.sh
+++ b/bin/build-package.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# export PYPI_HOST="pypi.sohonet.co.uk"
+# export TWINE_USERNAME="sohonet"
+# export TWINE_PASSWORD="..."
+
+python_build() {
+  python setup.py sdist bdist_wheel
+  twine upload --verbose --repository-url https://$PYPI_HOST dist/*
+}
+
+check_pypi_version() {
+
+  local versions_array=$(curl -s -XGET https://${TWINE_USERNAME}:${TWINE_PASSWORD}@${PYPI_HOST}/simple/workalendar/ 2>&1 | sed -e 's/<[^>]*>//g' | sed 's/[^0-9.]*\([0-9.]*\)\([a-z]\+[0-9]\+\)\?.*/\1\2/' | sed 's/\.$//' )
+  local package_version=$1
+
+  if [[ ! "$(echo $versions_array |  tr ' ' '\n' | grep "^${package_version}$")" ]];
+  then
+    echo "Pushing version ${package_version}"
+    python_build
+  else
+    echo "Skipping pypi push as version ${package_version} already exists"
+    exit 0
+  fi
+
+}
+
+main() {
+  local python_package_version=$(python setup.py --version)
+
+  git_hash=$(git log --pretty=format:'%h' -n 1)
+  echo "Creating Build for ${CIRCLE_BRANCH} version ${python_package_version}"
+  check_pypi_version $python_package_version
+}
+main
+
+

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ REQUIREMENTS = [
     'pyluach',
     'setuptools>=1.0',
 ]
-version = '7.2.0'
+version = '7.2.0.post1'
 __VERSION__ = version
 
 params = dict(

--- a/workalendar/europe/united_kingdom.py
+++ b/workalendar/europe/united_kingdom.py
@@ -23,6 +23,7 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
         2002: [(date(2002, 6, 3), "Queen’s Golden Jubilee"), ],
         2011: [(date(2011, 4, 29), "Royal Wedding"), ],
         2012: [(date(2012, 6, 5), "Queen’s Diamond Jubilee"), ],
+        2022: [(date(2022, 6, 3), "Queen’s Platinum Jubilee bank holiday"), ],
     }
 
     def get_early_may_bank_holiday(self, year):
@@ -48,6 +49,8 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
             spring_bank_holiday = date(1977, 6, 6)
         elif year == 2002:
             spring_bank_holiday = date(2002, 6, 4)
+        elif year == 2022:
+            spring_bank_holiday = date(2022, 6, 2)
         else:
             spring_bank_holiday = UnitedKingdom \
                 .get_last_weekday_in_month(year, 5, MON)


### PR DESCRIPTION
Patch from version 7.2.0, updated to cherry-pick support for 2022 jubilee bank hols from 78a2c01e8ef188b2ab7a15fd366417d8530302a1

